### PR TITLE
Remove EL6 Support

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -69,8 +69,8 @@ jobs:
     docker:
       - image: circleci/python:2.7
     environment:
-      DISTROS: trusty xenial bionic el6 el7 el8
-      DOCKER_DISTROS: trusty bionic centos6 centos7 centos8
+      DISTROS: trusty xenial bionic el7 el8
+      DOCKER_DISTROS: trusty bionic centos7 centos8
       DOCKER_RUN: |-
         docker run -w /code/st2-rbac-backend --volumes-from st2-rbac-backend-vol
             -e PKG_VERSION=$PKG_VERSION
@@ -128,13 +128,10 @@ jobs:
             eval ${DOCKER_RUN} stackstorm/buildpack:bionic make play deb
             docker cp st2-rbac-backend-vol:/code/st2-rbac-backend_${PKG_VERSION}-${PKG_RELEASE}_amd64.deb ~/st2-rbac-backend/build/bionic
             docker cp st2-rbac-backend-vol:/code/st2-rbac-backend_${PKG_VERSION}-${PKG_RELEASE}_amd64.changes ~/st2-rbac-backend/build/bionic
-            # 3. Build RHEL 6 packages
-            eval ${DOCKER_RUN} stackstorm/buildpack:centos6 make play rpm
-            docker cp st2-rbac-backend-vol:/code/st2-rbac-backend/build/x86_64/st2-rbac-backend-${PKG_VERSION}-${PKG_RELEASE}.x86_64.rpm ~/st2-rbac-backend/build/el6
-            # 4. Build RHEL 7 packages
+            # 3. Build RHEL 7 packages
             eval ${DOCKER_RUN} stackstorm/buildpack:centos7 make play rpm
             docker cp st2-rbac-backend-vol:/code/st2-rbac-backend/build/x86_64/st2-rbac-backend-${PKG_VERSION}-${PKG_RELEASE}.x86_64.rpm ~/st2-rbac-backend/build/el7
-            # 5. Build RHEL 8 packages
+            # 4. Build RHEL 8 packages
             eval ${DOCKER_RUN} stackstorm/buildpack:centos8 make play rpm
             docker cp st2-rbac-backend-vol:/code/st2-rbac-backend/build/x86_64/st2-rbac-backend-${PKG_VERSION}-${PKG_RELEASE}.x86_64.rpm ~/st2-rbac-backend/build/el8
             # List poduced artifacts
@@ -153,7 +150,7 @@ jobs:
       - image: circleci/ruby:2.4
     working_directory: /tmp/deploy
     environment:
-      DISTROS: trusty xenial bionic el6 el7 el8
+      DISTROS: trusty xenial bionic el7 el8
     steps:
       - checkout
       - attach_workspace:


### PR DESCRIPTION
CentOS 6 / RHEL 6 are to be fully deprecated. Remove the EL6  builds. 